### PR TITLE
Update copyright holder

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Relevant Healthcare
+Copyright 2017 Relevant Healthcare Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Fixing because it may matter during the Foothold transition 
as lawyers scrutinize our OSS usage and licenses.