### PR TITLE
Timeout pg_matview queries that exceed max wait time 

### DIFF
--- a/lib/view_backed/materialized_view.rb
+++ b/lib/view_backed/materialized_view.rb
@@ -109,6 +109,12 @@ module ViewBacked
         end
         connection.execute("SELECT * FROM pg_matviews WHERE matviewname = '#{name}';").first
       end
+    rescue ActiveRecord::QueryCanceled, PG::QueryCanceled => e
+      if ViewBacked.options[:max_wait_until_populated]
+        raise ViewBacked::MaxWaitUntilPopulatedTimeExceededError
+      else
+        raise e
+      end
     end
 
     def connection


### PR DESCRIPTION
On master the `max_wait_until_populated` option doesn't completely work. This PR makes it really work. The fix is explained in an in-code comment, but basically it wasn't working before because the `pg_matview` is locked when a materialized view is refreshing, so any queries to check on the status of the materialized view will just hang until the refresh finishes.

QA:
- I created a [branch in relevant](https://github.com/relevant-healthcare/relevant/tree/upgrade-viewbacked) that uses this commit of view_backed
- I deployed this branch to opendoor-staging
- I started refreshing one of the slow uds_table6a* views
- I navigated to the UDS Table 6A report.
- The page was loading. In the DB there was the `refresh materialized view ...` query and the blocked `select * from pg_matview` query. 
- I waited for 1 minute (the max wait time that was set in relevant)
- At exactly 1 minute, the page stopped loading and showed a server error (expected)
- At exactly 1 minute, the `select * from pg_matview` query was canceled in the DB.
- The `refresh materialized view ...` query contionute until completion, at which point I refreshed the page and saw the data.